### PR TITLE
infra: update codeowner file to amazon-braket/braket-dev

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, these accounts
 # will be requested for review when someone opens a pull request.
-* @amazon-braket/braket-dev
+* @amazon-braket/braket-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, these accounts
 # will be requested for review when someone opens a pull request.
-* @aws/amazon-braket-maintainers
+* @amazon-braket/braket-dev


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since moving the github repos to amazon-braket org, the existing CODEOWNERS file, which enforces restrictions on approval necessary for merging PRs, has broken due to the aws/amazon-braket-maintainers team no longer having access to the repos in the new org. We should update the CODEOWNERS in each of the repos to reference a team (either new or existing) in the new amazon-braket org.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
