### PR TITLE
fix: reverting oq3 variable names to previous versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3==1.28.3
 amazon-braket-default-simulator==1.20.0
 amazon-braket-pennylane-plugin==1.20.1
 amazon-braket-schemas==1.19.1
-amazon-braket-sdk==1.55.0
+amazon-braket-sdk==1.55.1
 amazon-braket-algorithm-library==1.4.1
 cvxpy==1.3.1
 dask==2023.1.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Syncing SDK to https://github.com/amazon-braket/amazon-braket-sdk-python/releases/tag/v1.55.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
