### PR TITLE
fix: add requirements to buildspec artifacts for packaging

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -35,4 +35,5 @@ artifacts:
   files:
     - envs/Braket.tgz
     - environment.yml
+    - requirements.txt
   name: CONDA_BUILD_RESULTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This artifact is needed for creating the LCC using the requirements file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
