### PR TITLE
fix: pin matplotlib to avoid python versioning issues

### DIFF
--- a/test/integ_tests/requirements.txt
+++ b/test/integ_tests/requirements.txt
@@ -1,7 +1,7 @@
 amazon-braket-sdk
 amazon-braket-pennylane-plugin
 cvxpy
-matplotlib
+matplotlib==3.6.3
 nbconvert
 pandas
 pennylane


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
