### PR TITLE
infra: upgrade to the 5.0 image build

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,4 +28,4 @@ jobs:
         python-version: 3.8
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0 -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

3.0 is no longer supported: https://gallery.ecr.aws/codebuild/amazonlinux2-x86_64-standard

This brings down the run time from `~9.5m` to `~7.5m`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
