### PR TITLE
fix: remove AHS examples slow on MacOS

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -15,7 +15,11 @@ EXCLUDED_NOTEBOOKS = [
     "VQE_chemistry_braket.ipynb",
     "6_Adjoint_gradient_computation.ipynb",
     # These notebooks are run from within a job (see Running_notebooks_as_hybrid_jobs.ipynb)
-    "0_Getting_started_papermill.ipynb"
+    "0_Getting_started_papermill.ipynb",
+    # Some AHS examples are running long especially on Mac. Removing while investigating
+    "04_Maximum_Independent_Sets_with_Analog_Hamiltonian_Simulation.ipynb",
+    "05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb",
+    
 ]
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This is temporary while an investigation is conducted. These examples are running normally on Linux and thus will still be published with NBIs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
