### PR TITLE
Add `ml-dtypes==0.2.0` requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ jaxlib==0.4.10
 jinja2==3.1.2
 markupsafe==2.1.3
 matplotlib==3.8.0
+ml-dtypes==0.2.0
 mypy-extensions==1.0.0
 openfermion==1.5.1
 openfermionpyscf==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ amazon-braket-sdk==1.59.1
 amazon-braket-algorithm-library==1.4.1
 cvxpy==1.4.1
 ipykernel==6.25.2
+ipython<8.17
 jax==0.4.10
 jaxlib==0.4.10
 jinja2==3.1.2


### PR DESCRIPTION
PennyLane notebooks fail with the error
```
AttributeError: module 'ml_dtypes' has no attribute 'float8_e4m3b11'
```
from JAX. JAX is incompatible with the new `ml_dtypes`, so the latter has to be [downgraded to 0.2.0](https://github.com/google/jax/issues/17693#issuecomment-1730176594).

Also had to constrain `ipython<8.17` due to an [issue](https://github.com/ipython/ipython/issues/14230) with the latest IPython release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
