### PR TITLE
infra: add conda env size logging and use xz compression

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
       - du -hs envs/Braket.tgz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 1 --n-threads -1
       - du -hs envs/Braket.tgz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,8 +30,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda clean --all
-      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - du -hs envs/Braket.tgz
 
 artifacts:
   files:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda clean --all
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
 
 artifacts:
   files:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,6 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda clean --all
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
       - du -hs envs/Braket.tgz
 

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 6 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 1 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,12 +30,12 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 0 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tbz2 --compress-level 6 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:
   files:
-    - envs/Braket.txz
+    - envs/Braket.tbz2
     - environment.yml
     - requirements.txt
   name: CONDA_BUILD_RESULTS

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,6 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
+      - conda clean --all
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 1 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 3 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 3 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 0 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tbz2 --compress-level 6 --n-threads -1 
-      - du -hs envs/Braket.txz
+      - du -hs envs/Braket.tbz2
 
 artifacts:
   files:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 1 --n-threads -1
+      - conda clean --all
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
       - du -hs envs/Braket.tgz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,12 +30,12 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
-      - du -hs envs/Braket.tgz
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 6 --n-threads -1 
+      - du -hs envs/Braket.txz
 
 artifacts:
   files:
-    - envs/Braket.tgz
+    - envs/Braket.txz
     - environment.yml
     - requirements.txt
   name: CONDA_BUILD_RESULTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add memory output and benchmark different compression levels. `XZ` suffers from slower decompression so testing on the startup will be added.

| Compression Level |`txz` size | Conda action runtime | 
|--------|--------|--------|
| 0 | 388M | 4m 48s |
| 1 | 364M | 4m 58s  |
| 3 | 345 M | 5m 21s |
| 6 | 304M | 6m 40s  | 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
