### PR TITLE
infra: add image size and use zstd to compress the conda env

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
       - du -hs envs/Braket.tgz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd -9 envs/Braket.tar -T0
+      - zstd --ultra envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd --ultra envs/Braket.tar -T0
+      - zstd --fast=9 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd --ultra -22 envs/Braket.tar -T0
+      - zstd --ultra --fast=22 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 1 --n-threads -1
       - du -hs envs/Braket.tgz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,8 +30,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd --ultra --fast=22 envs/Braket.tar -T0
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
+      - zstd -9 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,8 +30,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda clean --all
-      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - du -hs envs/Braket.tgz
 
 artifacts:
   files:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,8 +30,6 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda clean --index-cache
-      - pip cache purge
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda clean --all
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
+      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
 
 artifacts:
   files:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,6 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda clean --all
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
       - du -hs envs/Braket.tgz
 

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,6 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
+      - conda clean --index-cache
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,12 +30,13 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tbz2 --compress-level 6 --n-threads -1 
-      - du -hs envs/Braket.tbz2
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 6 --n-threads -1
+      - zstd -2 envs/Braket.tar
+      - du -hs envs/Braket.tar.zst
 
 artifacts:
   files:
-    - envs/Braket.tbz2
+    - envs/Braket.tar.zst
     - environment.yml
     - requirements.txt
   name: CONDA_BUILD_RESULTS

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 6 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 1 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,12 +30,12 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 0 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tbz2 --compress-level 6 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:
   files:
-    - envs/Braket.txz
+    - envs/Braket.tbz2
     - environment.yml
     - requirements.txt
   name: CONDA_BUILD_RESULTS

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd -6 envs/Braket.tar
+      - zstd -19 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,6 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
+      - conda clean --all
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --n-threads -1
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 1 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 3 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd --fast=9 envs/Braket.tar -T0
+      - zstd --ultra -22 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 3 --n-threads -1 
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 0 --n-threads -1 
       - du -hs envs/Braket.txz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tbz2 --compress-level 6 --n-threads -1 
-      - du -hs envs/Braket.txz
+      - du -hs envs/Braket.tbz2
 
 artifacts:
   files:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,8 +30,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 6 --n-threads -1
-      - zstd -2 envs/Braket.tar
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
+      - zstd -6 envs/Braket.tar
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,6 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda clean --index-cache
+      - pip cache purge
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 9 --n-threads -1
-      - zstd -19 envs/Braket.tar -T0
+      - zstd -9 envs/Braket.tar -T0
       - du -hs envs/Braket.tar.zst
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 1 --n-threads -1
+      - conda clean --all
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
       - du -hs envs/Braket.tgz
 
 artifacts:

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,12 +30,12 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 6 --n-threads -1
-      - du -hs envs/Braket.tgz
+      - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.txz --compress-level 6 --n-threads -1 
+      - du -hs envs/Braket.txz
 
 artifacts:
   files:
-    - envs/Braket.tgz
+    - envs/Braket.txz
     - environment.yml
     - requirements.txt
   name: CONDA_BUILD_RESULTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Tried out `xz`, `bzip2`, and `zstd`. This proved to be the best combination of speed for compression, decompression, and size of the object.

Runtime: `4m 32s`
Object size: `366M	envs/Braket.tar.zst`

The compressed object at `1` was around `400M` but was slightly faster. As this gives a nice space savings with only a small uptick in runtime, this level was added.

For comparison, `xz`:

| Compression Level |`txz` size | Conda action runtime | 
|--------|--------|--------|
| 0 | 388M | 4m 48s |
| 1 | 364M | 4m 58s  |
| 3 | 345 M | 5m 21s |
| 6 | 304M | 6m 40s  | 

The main reason `xz` and `bzip2` were not chosen was due to the longer compression time which added a minimum of 20 seconds to what the current runtimes are.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
