### PR TITLE
Unmark examples folder as documentation for stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+examples/ -linguist-documentation


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change should make github include the `examples` directory in language stats (as documented here https://github.com/github-linguist/linguist/blob/master/docs/overrides.md) and reflect the usage of Jupyter Notebooks in this repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
