### PR TITLE
Utilize the local build image to expedite docker build times

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -31,4 +31,4 @@ jobs:
         docker image pull public.ecr.aws/codebuild/local-builds:latest
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/standard:5.0 -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,4 +28,5 @@ jobs:
         python-version: 3.11.x
     - name: Build conda environment
       run: |
+        docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
         ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,5 +28,4 @@ jobs:
         python-version: 3.11.x
     - name: Build conda environment
       run: |
-        docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 && ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -31,4 +31,4 @@ jobs:
         docker image pull public.ecr.aws/codebuild/local-builds:latest
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/local-builds:latest -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -31,4 +31,4 @@ jobs:
         docker image pull public.ecr.aws/codebuild/local-builds:latest
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/local-builds:latest -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -31,4 +31,4 @@ jobs:
         docker image pull public.ecr.aws/codebuild/local-builds:latest
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/standard:5.0 -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Build conda environment
       run: |
         docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: 3.11.x
     - name: Pull Docker image
       run: |
-        docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        docker image pull public.ecr.aws/codebuild/local-builds:latest
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/local-builds:latest -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -26,6 +26,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.11.x
+    - name: Pull Docker image
+      run: |
+        docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
     - name: Build conda environment
       run: |
-        docker image pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 && ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -5,7 +5,7 @@ env:
 phases:
   install:
     commands:
-      - yum -y install wget
+      - yum -y install wget || apt-get -y install wget
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-latest-Linux-x86_64.sh

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - pip cache purge
       - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
       - ls /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
-      - readelf -f /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
+      - nm /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - du -h /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,6 +31,7 @@ phases:
       - pip cache purge
       - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
       - ls /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
+      - yum install binutils
       - nm /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - du -h /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -5,6 +5,7 @@ env:
 phases:
   install:
     commands:
+      - apt install wget
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-py311_23.5.2-0-Linux-x86_64.sh

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -6,7 +6,6 @@ phases:
   install:
     commands:
       - yum -y install wget
-      - yum -y install binutils
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-latest-Linux-x86_64.sh
@@ -30,8 +29,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - pip cache purge
-      - du -h -d 4 /root/Braket/miniconda3/envs/$BRAKET_ENV
-      - strip --strip-debug /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
+      - du -h -d 3 /root/Braket/miniconda3/envs/$BRAKET_ENV
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -29,7 +29,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - pip cache purge
-      - du -h -d 4 /root/Braket/miniconda3/envs/$BRAKET_ENV
+      - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,6 +31,7 @@ phases:
       - pip cache purge
       - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
       - ls /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
+      - du -h /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -31,6 +31,7 @@ phases:
       - pip cache purge
       - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
       - ls /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
+      - readelf -f /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - du -h /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -5,7 +5,7 @@ env:
 phases:
   install:
     commands:
-      - apt install wget
+      - apt-get install wget
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-py311_23.5.2-0-Linux-x86_64.sh

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -21,7 +21,7 @@ phases:
       - conda config --set default_threads 2
       - conda config --set channel_priority strict
       - conda config --set solver libmamba
-      - conda install -q -c conda-forge conda-pack=0.7.1
+      - conda install -y -q -c conda-forge conda-pack=0.7.1
   build:
     commands:
       - BRAKET_ENV=Braket

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -6,6 +6,7 @@ phases:
   install:
     commands:
       - yum -y install wget
+      - yum -y install binutils
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-latest-Linux-x86_64.sh

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -5,7 +5,7 @@ env:
 phases:
   install:
     commands:
-      - yum install wget
+      - yum -y install wget
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-py311_23.5.2-0-Linux-x86_64.sh

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -29,11 +29,8 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - pip cache purge
-      - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
-      - ls /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
-      - yum install binutils
-      - nm /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
-      - du -h /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
+      - du -h -d 4 /root/Braket/miniconda3/envs/$BRAKET_ENV
+      - strip --strip-debug /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning/lightning_qubit_ops.cpython-310-x86_64-linux-gnu.so
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -21,7 +21,7 @@ phases:
       - conda config --set default_threads 2
       - conda config --set channel_priority strict
       - conda config --set solver libmamba
-      - conda install -y -q -c conda-forge conda-pack=0.7.1
+      - conda install -y -q --freeze-installed -c conda-forge conda-pack=0.7.1
   build:
     commands:
       - BRAKET_ENV=Braket

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -29,7 +29,6 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - pip cache purge
-      - du -h -d 3 /root/Braket/miniconda3/envs/$BRAKET_ENV
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,6 +30,7 @@ phases:
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - pip cache purge
       - du -h -d 2 /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
+      - ls /root/Braket/miniconda3/envs/$BRAKET_ENV/lib/python3.10/site-packages/pennylane_lightning
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -9 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse
       - du -hs envs/Braket.tar.zst

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -5,7 +5,7 @@ env:
 phases:
   install:
     commands:
-      - apt-get install wget
+      - yum install wget
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
       - export LCC_MINICONDA_INSTALLER=Miniconda3-py311_23.5.2-0-Linux-x86_64.sh

--- a/nbi/codebuild_build.sh
+++ b/nbi/codebuild_build.sh
@@ -148,11 +148,6 @@ then
     docker_command+=" -v \"$environment_variable_file_dir:/LocalBuild/envFile/\" -e \"ENV_VAR_FILE=$environment_variable_file_basename\""
 fi
 
-if [ -n "$local_agent_image" ]
-then
-    docker_command+=" -e \"LOCAL_AGENT_IMAGE_NAME=$local_agent_image\""
-fi
-
 if $awsconfig_flag
 then
     if [ -d "$HOME/.aws" ]

--- a/nbi/codebuild_build.sh
+++ b/nbi/codebuild_build.sh
@@ -148,6 +148,11 @@ then
     docker_command+=" -v \"$environment_variable_file_dir:/LocalBuild/envFile/\" -e \"ENV_VAR_FILE=$environment_variable_file_basename\""
 fi
 
+if [ -n "$local_agent_image" ]
+then
+    docker_command+=" -e \"LOCAL_AGENT_IMAGE_NAME=$local_agent_image\""
+fi
+
 if $awsconfig_flag
 then
     if [ -d "$HOME/.aws" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,14 +17,14 @@ markupsafe==2.1.3
 matplotlib==3.8.2
 ml-dtypes==0.3.2
 mypy-extensions==1.0.0
+numpy==1.25.2 --global-option=“-g0” --global-option=“-Wl,–strip-all”
 openfermion==1.5.1 # later versions pin scipy to a version that is incompatible
 openfermionpyscf==0.5
 optax==0.1.7
-numpy==1.25.2
 pandas==2.1.4
 pennylane==0.33.1
 PennyLane-Lightning==0.34.0
 qiskit-aer==0.13.1
 qiskit_braket_provider==0.0.5
 qiskit-terra==0.45.1
-scipy==1.11.4
+scipy==1.11.4 --global-option=“-g0” --global-option=“-Wl,–strip-all”

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,14 +17,14 @@ markupsafe==2.1.3
 matplotlib==3.8.2
 ml-dtypes==0.3.2
 mypy-extensions==1.0.0
-numpy==1.25.2 --global-option=“-g0” --global-option=“-Wl,–strip-all”
+numpy==1.25.2
 openfermion==1.5.1 # later versions pin scipy to a version that is incompatible
 openfermionpyscf==0.5
 optax==0.1.7
 pandas==2.1.4
 pennylane==0.33.1
-PennyLane-Lightning==0.34.0
+PennyLane-Lightning==0.34.0 --global-option=“-Wl,–strip-all”
 qiskit-aer==0.13.1
 qiskit_braket_provider==0.0.5
 qiskit-terra==0.45.1
-scipy==1.11.4 --global-option=“-g0” --global-option=“-Wl,–strip-all”
+scipy==1.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
---use-feature fast-deps
-
 botocore==1.34.14
 awscli==1.32.14
 boto3==1.34.14
@@ -23,7 +21,7 @@ openfermionpyscf==0.5
 optax==0.1.7
 pandas==2.1.4
 pennylane==0.33.1
-PennyLane-Lightning==0.34.0 --global-option=“-Wl,–strip-all”
+PennyLane-Lightning==0.34.0
 qiskit-aer==0.13.1
 qiskit_braket_provider==0.0.5
 qiskit-terra==0.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--use-feature fast-deps
+
 botocore==1.31.84
 awscli==1.29.84
 boto3==1.28.84


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Runtime drops from 5 minutes to 3 minutes. 

Installing wget is needed as it is not on the local build image. The rest of the needed files are from the miniconda install and will function as before.

Currently, the build utilizes the [standard-5.0](https://github.com/aws/aws-codebuild-docker-images/blob/master/al2/x86_64/standard/5.0/Dockerfile) image. This contains way more is needed for setting up the conda environment so to reduce developer wait time and Github runner usage time, swapping to the local agent was opted for.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
