### PR TITLE
update the kernel used by testbook

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -59,7 +59,7 @@ def test_all_notebooks(notebook_dir, notebook_file, mock_level):
     os.chdir(root_path)
     os.chdir(notebook_dir)
     path_to_utils, path_to_mocks = get_mock_paths(notebook_dir, notebook_file)
-    with testbook(notebook_file, timeout=600) as tb:
+    with testbook(notebook_file, timeout=600, kernel_name='conda_braket') as tb:
         # We check the existing notebook output for errors before we execute the
         # notebook because it will change after executing it.
         check_cells_for_error_output(tb.cells)

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -59,7 +59,9 @@ def test_all_notebooks(notebook_dir, notebook_file, mock_level):
     os.chdir(root_path)
     os.chdir(notebook_dir)
     path_to_utils, path_to_mocks = get_mock_paths(notebook_dir, notebook_file)
-    with testbook(notebook_file, timeout=600, kernel_name='conda_braket') as tb:
+    # Try to use the conda_braket kernel if installed, otherwise fall back to the default value of python3
+    kernel = 'conda_braket' if 'conda_braket' kernelspec.find_kernel_specs().keys() else 'python3'
+    with testbook(notebook_file, timeout=600, kernel_name=kernel) as tb:
         # We check the existing notebook output for errors before we execute the
         # notebook because it will change after executing it.
         check_cells_for_error_output(tb.cells)

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -5,6 +5,7 @@ import pytest
 from testbook import testbook
 from nbconvert import HTMLExporter
 from importlib.machinery import SourceFileLoader
+from jupyter_client import kernelspec
 
 # These notebooks have syntax or dependency issues that prevent them from being tested.
 EXCLUDED_NOTEBOOKS = [
@@ -60,7 +61,7 @@ def test_all_notebooks(notebook_dir, notebook_file, mock_level):
     os.chdir(notebook_dir)
     path_to_utils, path_to_mocks = get_mock_paths(notebook_dir, notebook_file)
     # Try to use the conda_braket kernel if installed, otherwise fall back to the default value of python3
-    kernel = 'conda_braket' if 'conda_braket' kernelspec.find_kernel_specs().keys() else 'python3'
+    kernel = 'conda_braket' if 'conda_braket' in kernelspec.find_kernel_specs().keys() else 'python3'
     with testbook(notebook_file, timeout=600, kernel_name=kernel) as tb:
         # We check the existing notebook output for errors before we execute the
         # notebook because it will change after executing it.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Testbook defaults to using [`python3`](https://github.com/nteract/testbook/blob/62d7bd9642d70d27a90c6ab7f1d441d13d48a97d/testbook/testbook.py#L31) unless a kernel is specified. Here, we try to use conda_braket and fallback to python3 if the env is not built. This may be the case for local development and execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
