### PR TITLE
fix: add new fields for the AHS device mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ awscli==1.32.29
 boto3==1.34.29
 amazon-braket-default-simulator==1.20.1
 amazon-braket-pennylane-plugin==1.24.2
-amazon-braket-schemas==1.19.1.post0
+amazon-braket-schemas==1.20.1
 amazon-braket-sdk==1.68.2
 amazon-braket-algorithm-library==1.4.5
 cvxpy==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ awscli==1.32.29
 boto3==1.34.29
 amazon-braket-default-simulator==1.20.1
 amazon-braket-pennylane-plugin==1.24.2
-amazon-braket-schemas==1.20.1
+amazon-braket-schemas==1.20.2
 amazon-braket-sdk==1.68.2
 amazon-braket-algorithm-library==1.4.5
 cvxpy==1.4.2

--- a/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
+++ b/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
@@ -68,7 +68,7 @@
     },
     "performance": {
       "lattice": {
-        "positionErrorAbs": 1E-7,
+        "positionErrorAbs": 1.47e-7,
         "sitePositionError": 0.025e-6,
         "atomPositionError": 0.025e-6,
         "fillingErrorTypical": 0.005,

--- a/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
+++ b/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
@@ -68,13 +68,51 @@
     },
     "performance": {
       "lattice": {
-        "positionErrorAbs": 1E-7
+        "positionErrorAbs": 1E-7,
+        "sitePositionError": 0.025e-6,
+        "atomPositionError": 0.025e-6,
+        "fillingErrorTypical": 0.005,
+        "fillingErrorWorst": 0.01,
+        "vacancyErrorTypical": 0.005,
+        "vacancyErrorWorst": 0.005,
+        "atomLossProbabilityTypical": 0.01,
+        "atomLossProbabilityWorst": 0.01,
+        "atomCaptureProbabilityTypical": 0.01,
+        "atomCaptureProbabilityWorst": 0.01,
+        "atomDetectionErrorFalsePositiveTypical": 0.01,
+        "atomDetectionErrorFalsePositiveWorst": 0.01,
+        "atomDetectionErrorFalseNegativeTypical": 0.01,
+        "atomDetectionErrorFalseNegativeWorst": 0.01,
       },
       "rydberg": {
         "rydbergGlobal": {
-          "rabiFrequencyErrorRel": 0.02
-        }
-      }
+          "rabiFrequencyErrorRel": 0.02,
+          "rabiFrequencyGlobalErrorRel": 0.01,
+          "rabiFrequencyInhomogeneityRel": 0.01,
+          "groundDetectionError": 0.01,
+          "rydbergDetectionError": 0.1,
+          "groundPrepError": 0.01,
+          "rydbergPrepErrorBest": 0.05,
+          "rydbergPrepErrorWorst": 0.05,
+          "T1Single": 100e-6,
+          "T1Ensemble": 100e-6,
+          "T2StarSingle": 5e-6,
+          "T2StarEnsemble": 5e-6,
+          "T2EchoSingle": 5e-6,
+          "T2EchoEnsemble": 5e-6,
+          "T2RabiSingle": 5e-6,
+          "T2RabiEnsemble": 5e-6,
+          "T2BlockadedRabiSingle": 5e-6,
+          "T2BlockadedRabiEnsemble": 5e-6,
+          "detuningError": 1e6,
+          "detuningInhomogeneity": 1e6,
+          "rabiAmplitudeRampCorrection": [
+            {"rampTime": 50e-9, "rabiCorrection": 0.92},
+            {"rampTime": 75e-9, "rabiCorrection": 0.97},
+            {"rampTime": 100e-9, "rabiCorrection": 1.00},
+          ],
+        },
+      },
     }
   }
 }

--- a/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
+++ b/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
@@ -110,9 +110,9 @@
             {"rampTime": 50e-9, "rabiCorrection": 0.92},
             {"rampTime": 75e-9, "rabiCorrection": 0.97},
             {"rampTime": 100e-9, "rabiCorrection": 1.00},
-          ],
-        },
-      },
+          ]
+        }
+      }
     }
   }
 }

--- a/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
+++ b/test/integ_tests/analog_hamiltonian_simulation/ahs_device_capabilities.json
@@ -82,7 +82,7 @@
         "atomDetectionErrorFalsePositiveTypical": 0.01,
         "atomDetectionErrorFalsePositiveWorst": 0.01,
         "atomDetectionErrorFalseNegativeTypical": 0.01,
-        "atomDetectionErrorFalseNegativeWorst": 0.01,
+        "atomDetectionErrorFalseNegativeWorst": 0.01
       },
       "rydberg": {
         "rydbergGlobal": {
@@ -109,7 +109,7 @@
           "rabiAmplitudeRampCorrection": [
             {"rampTime": 50e-9, "rabiCorrection": 0.92},
             {"rampTime": 75e-9, "rabiCorrection": 0.97},
-            {"rampTime": 100e-9, "rabiCorrection": 1.00},
+            {"rampTime": 100e-9, "rabiCorrection": 1.00}
           ]
         }
       }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will unblock dependabot updates for the new schemas release. There was AHS properties added so this updates the mock to include those.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
