### PR TITLE
infra: allow hatch to pull in deps referenced by repo and update qiskit-terra to qiskit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ pytest -n auto -ra -v --durations=0 test/
 
 [[tool.hatch.envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ pandas==2.2.0
 pennylane==0.34.0
 PennyLane-Lightning==0.34.0
 qiskit-aer==0.13.2
-qiskit_braket_provider==0.0.5
-qiskit-terra==0.45.2
+qiskit_braket_provider==0.1.1
+qiskit=1.0.0
 scipy==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ pennylane==0.34.0
 PennyLane-Lightning==0.34.0
 qiskit-aer==0.13.2
 qiskit_braket_provider==0.1.1
-qiskit=1.0.0
+qiskit==1.0.0
 scipy==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ pennylane==0.34.0
 PennyLane-Lightning==0.34.0
 qiskit-aer==0.13.2
 qiskit_braket_provider==0.1.1
-qiskit==1.0.0
+qiskit==0.46.0
 scipy==1.12.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is beneficial for custom repos and for repos that are being tested. Also qiskit-terra was renamed to qiskit so we are pulling in both of these due to the naming issue. This prevents dependency issues from occurring.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
