### PR TITLE
infra: introduce loading steal for parallelized tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 test = """
 python -m ipykernel install --user --name "conda_braket" --display-name "conda_braket"
-pytest -n logical -ra -v --durations=0 test/
+pytest --dist worksteal -n logical -ra -v --durations=0 test/
 """
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This allows workers to take up tests if they are idle. This is especially useful for tests where runtimes are not well distributed and one worker may finish way before another.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
