### PR TITLE
remove mentioning of oxford quantum circuits

### DIFF
--- a/examples/braket_features/Verbatim_Compilation.ipynb
+++ b/examples/braket_features/Verbatim_Compilation.ipynb
@@ -28,8 +28,7 @@
     "\n",
     "* [Recap: Running circuits on Amazon Braket](#Recap)\n",
     "* [Using verbatim compilation to run circuits without further compilation](#Verbatim)\n",
-    "* [Programming verbatim circuits onto the Rigetti device](#Rigetti)\n",
-    "* [Programming verbatim circuits onto the Oxford Quantum Circuits device](#OQC)"
+    "* [Programming verbatim circuits onto the Rigetti device](#Rigetti)"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

There is one last mentioning of OQC that wasn't removed

*Description of changes:*

Remove the mentioning of "Oxford Quantum circuits"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
