### PR TITLE
Exclude noisy AHS simulation example from integ tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ qiskit-braket-provider==0.4.0
 qiskit==1.0.2
 scipy==1.13.1
 scs<3.2.6 # Pinned for GLIBC 2.26 compatability
+sympy<1.13 # Sympy 1.13 produces different results for Simon's algorithm

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -20,7 +20,7 @@ EXCLUDED_NOTEBOOKS = [
     # Some AHS examples are running long especially on Mac. Removing while investigating
     "04_Maximum_Independent_Sets_with_Analog_Hamiltonian_Simulation.ipynb",
     "05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb",
-    "09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays.ipynb"
+    "09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays.ipynb",
     "Using_the_experimental_local_simulator.ipynb"
 ]
 

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -20,6 +20,7 @@ EXCLUDED_NOTEBOOKS = [
     # Some AHS examples are running long especially on Mac. Removing while investigating
     "04_Maximum_Independent_Sets_with_Analog_Hamiltonian_Simulation.ipynb",
     "05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb",
+    "09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays.ipynb"
     "Using_the_experimental_local_simulator.ipynb"
 ]
 


### PR DESCRIPTION
Notebook takes too long to run.

Also pinned sympy<1.13 (see https://github.com/amazon-braket/amazon-braket-algorithm-library/pull/149)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
