### PR TITLE
Add simulator v2 install and precompilation to container build steps

### DIFF
--- a/examples/pulse_control/1_Bringup_experiments.ipynb
+++ b/examples/pulse_control/1_Bringup_experiments.ipynb
@@ -461,12 +461,12 @@
     "detuning=250e3\n",
     "x90 = experiment_configuration[device_name][\"x90_wf\"]\n",
     "\n",
-    "delay = FreeParameter(\"delay\")\n",
+    "delay_duration = FreeParameter(\"delay_duration\")\n",
     "ramsey_spectroscopy = ( \n",
     "    PulseSequence()\n",
     "    .set_frequency(drive_frame, drive_frame.frequency - detuning)\n",
     "    .play(drive_frame, x90)\n",
-    "    .delay(drive_frame, delay)\n",
+    "    .delay(drive_frame, delay_duration)\n",
     "    .play(drive_frame, x90)\n",
     "    .capture_v0(readout_frame)\n",
     ")"
@@ -491,7 +491,7 @@
     "delays = np.arange(start_delay, end_delay, 512e-9)\n",
     "N_shots=100\n",
     "\n",
-    "pulse_sequences = [ramsey_spectroscopy(delay=delay) for delay in delays]\n",
+    "pulse_sequences = [ramsey_spectroscopy(delay_duration=delay_duration) for delay in delays]\n",
     "\n",
     "batch = device.run_batch(pulse_sequences, shots=N_shots)"
    ]

--- a/examples/pulse_control/1_Bringup_experiments.ipynb
+++ b/examples/pulse_control/1_Bringup_experiments.ipynb
@@ -491,7 +491,7 @@
     "delays = np.arange(start_delay, end_delay, 512e-9)\n",
     "N_shots=100\n",
     "\n",
-    "pulse_sequences = [ramsey_spectroscopy(delay_duration=delay_duration) for delay in delays]\n",
+    "pulse_sequences = [ramsey_spectroscopy(delay_duration=delay) for delay in delays]\n",
     "\n",
     "batch = device.run_batch(pulse_sequences, shots=N_shots)"
    ]

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -22,7 +22,6 @@ phases:
       - conda config --set channel_priority strict
       - conda config --set solver libmamba
       - conda install -y -q --freeze-installed -c conda-forge conda-pack=0.7.1
-      - conda init bash
   build:
     commands:
       - BRAKET_ENV=Braket

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -22,13 +22,14 @@ phases:
       - conda config --set channel_priority strict
       - conda config --set solver libmamba
       - conda install -y -q --freeze-installed -c conda-forge conda-pack=0.7.1
+      - conda init bash
   build:
     commands:
       - BRAKET_ENV=Braket
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - conda activate $BRAKET_ENV
+      - source activate base && conda activate $BRAKET_ENV
       - python -c "import braket.simulator_v2"
       - pip cache purge
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -28,7 +28,9 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
+      - export JULIA_HOME=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/julia_env/pyjuliapkg/install/bin
       - export PYTHON_JULIAPKG_PROJECT=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/julia_env
+      - export JULIA_PKGDIR=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/.julia
       - export CONDA_JL_HOME=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV
       - export JULIA_CONDAPKG_ENV=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV
       - export JULIA_CONDAPKG_BACKEND=Current

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -28,6 +28,8 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
+      - conda activate $BRAKET_ENV
+      - python -c "import braket.simulator_v2"
       - pip cache purge
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -16 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -28,6 +28,10 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
+      - export PYTHON_JULIAPKG_PROJECT=$HOME/anaconda3/envs/$BRAKET_ENV/julia_env
+      - export CONDA_JL_HOME=$HOME/anaconda3/envs/$BRAKET_ENV
+      - export JULIA_CONDAPKG_ENV=$HOME/anaconda3/envs/$BRAKET_ENV
+      - export JULIA_CONDAPKG_BACKEND=Current
       - source activate base && conda activate $BRAKET_ENV && python -c "import braket.simulator_v2"
       - pip cache purge
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -28,9 +28,9 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - export PYTHON_JULIAPKG_PROJECT=$HOME/anaconda3/envs/$BRAKET_ENV/julia_env
-      - export CONDA_JL_HOME=$HOME/anaconda3/envs/$BRAKET_ENV
-      - export JULIA_CONDAPKG_ENV=$HOME/anaconda3/envs/$BRAKET_ENV
+      - export PYTHON_JULIAPKG_PROJECT=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/julia_env
+      - export CONDA_JL_HOME=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV
+      - export JULIA_CONDAPKG_ENV=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV
       - export JULIA_CONDAPKG_BACKEND=Current
       - source activate base && conda activate $BRAKET_ENV && python -c "import braket.simulator_v2"
       - pip cache purge

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
       - export JULIA_HOME=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/julia_env/pyjuliapkg/install/bin
       - export PYTHON_JULIAPKG_PROJECT=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/julia_env
-      - export JULIA_PKGDIR=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/.julia
+      - export JULIA_DEPOT_PATH=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV/.julia
       - export CONDA_JL_HOME=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV
       - export JULIA_CONDAPKG_ENV=$LCC_MINICONDA_INSTALL_DIR/envs/$BRAKET_ENV
       - export JULIA_CONDAPKG_BACKEND=Current

--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -29,8 +29,7 @@ phases:
       - mkdir -p envs
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package --solver libmamba
-      - source activate base && conda activate $BRAKET_ENV
-      - python -c "import braket.simulator_v2"
+      - source activate base && conda activate $BRAKET_ENV && python -c "import braket.simulator_v2"
       - pip cache purge
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar --compress-level 1 --n-threads -1
       - zstd -16 envs/Braket.tar -T0 --auto-threads=logical --rsyncable --sparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ botocore==1.34.113
 awscli==1.32.113
 boto3==1.34.113
 amazon-braket-default-simulator==1.23.2
+amazon-braket-simulator-v2==0.2.2
 amazon-braket-pennylane-plugin==1.27.3
 amazon-braket-schemas==1.22.0
 amazon-braket-sdk==1.80.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,19 @@
 botocore==1.34.113
 awscli==1.32.113
 boto3==1.34.113
-amazon-braket-default-simulator==1.23.2
+amazon-braket-default-simulator==1.26.0
 amazon-braket-simulator-v2==0.2.2
 amazon-braket-pennylane-plugin==1.27.3
 amazon-braket-schemas==1.22.0
-amazon-braket-sdk==1.80.0
+amazon-braket-sdk==1.84.0
 amazon-braket-algorithm-library==1.4.11
 cvxpy==1.5.1
 ipykernel==6.29.4
 jax==0.4.28
 jaxlib==0.4.28
 jinja2==3.1.4
+juliacall==0.9.20
+juliapkg==0.1.13
 markupsafe==2.1.5
 matplotlib==3.9.0
 ml-dtypes==0.4.0
@@ -29,4 +31,5 @@ qiskit-braket-provider==0.4.0
 qiskit==1.0.2
 scipy==1.13.1
 scs<3.2.6 # Pinned for GLIBC 2.26 compatability
+semver==3.0.2
 sympy<1.13 # Sympy 1.13 produces different results for Simon's algorithm

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,10 +25,11 @@ optax==0.2.2
 pandas==2.2.2
 pennylane==0.35.1
 PennyLane-Lightning==0.35.1
-qiskit-aer==0.14.0.1
+qiskit-aer==0.14.2
 qiskit-algorithms==0.3.0
-qiskit-braket-provider==0.4.0
-qiskit==1.0.2
+qiskit-braket-provider==0.4.1
+qiskit-ionq==0.5.4
+qiskit==1.1.2
 scipy==1.13.1
 scs<3.2.6 # Pinned for GLIBC 2.26 compatability
 semver==3.0.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
#606 added an example using v2 local simulator. This PR tests running the `import braket.simulator_v2` command at container build time so that the Julia installation and precompilation results are cached in the container image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
