### PR TITLE
Include IQM in devices with verbatim mode supported

### DIFF
--- a/examples/braket_features/Verbatim_Compilation.ipynb
+++ b/examples/braket_features/Verbatim_Compilation.ipynb
@@ -248,7 +248,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "    <b>Note:</b> <code>add_verbatim_box</code> is currently only supported on Rigetti, IonQ, and IQM devices.\n",
+    "    <b>Note:</b> <code>add_verbatim_box</code> is currently supported on Rigetti, IonQ, and IQM devices.\n",
     "</div>"
    ]
   },

--- a/examples/braket_features/Verbatim_Compilation.ipynb
+++ b/examples/braket_features/Verbatim_Compilation.ipynb
@@ -248,7 +248,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "    <b>Note:</b> <code>add_verbatim_box</code> is currently only supported on Rigetti, and IonQ devices.\n",
+    "    <b>Note:</b> <code>add_verbatim_box</code> is currently only supported on Rigetti, IonQ, and IQM devices.\n",
     "</div>"
    ]
   },


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Fixing a warning box that didn't include IQM. This has already caused some confusion: https://github.com/qiboteam/qibo-cloud-backends/pull/30#discussion_r1760729625

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
