### PR TITLE
fix: setting type of array length to const int in OQ3 example

### DIFF
--- a/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb
+++ b/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb
@@ -1565,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "5acb72003cd0a0f5",
    "metadata": {
     "ExecuteTime": {
@@ -1586,7 +1586,7 @@
     "    }\n",
     "}\n",
     "\n",
-    "int[32] n = 5;\n",
+    "const int[32] n = 5;\n",
     "bit[n + 1] c;\n",
     "qubit[n + 1] q;\n",
     "\n",


### PR DESCRIPTION
*Issue*
In https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb -- first of "Advanced OpenQASM features", the
```
int[32] n = 5;
bit[n + 1] c;
qubit[n + 1] q;
```
is invalid OpenQASM. `n` should be a `const`

Ref: https://openqasm.com/language/types.html#arrays citation for this (look for the Note: "Note that bit, bit[n] and stretch are not valid array base types, nor are any quantum types.")

*Description of changes:*

Following the example here: https://openqasm.com/language/types.html#qubits, I made the change 

`int[32] n = 5;` -> `const int[32] n = 5;` in code cell 39 of https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb

I also verified that the cell, and the next run correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
