### PR TITLE
fix: exclude device-dependent tests from test_all_notebooks

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -31,6 +31,14 @@ EXCLUDED_NOTEBOOKS = [
     "0_hello_cudaq_jobs.ipynb",
     "1_simulation_with_GPUs.ipynb",
     "2_parallel_simulations.ipynb",
+    # Notebooks that require devices to be online
+    "Randomness_Generation.ipynb",
+    "Allocating_Qubits_on_QPU_Devices.ipynb",
+    "Getting_Started_with_OpenQASM_on_Braket.ipynb",
+    "0_Getting_Started.ipynb",
+    "Noise_models_on_Rigetti.ipynb",
+    "2_Running_quantum_circuits_on_QPU_devices.ipynb",
+    "Verbatim_Compilation.ipynb",
 ]
 
 if (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
