### PR TITLE
fix: use released cudaq version in dockerfile

### DIFF
--- a/examples/nvidia_cuda_q/container/Dockerfile
+++ b/examples/nvidia_cuda_q/container/Dockerfile
@@ -1,13 +1,12 @@
 FROM 292282985366.dkr.ecr.us-west-2.amazonaws.com/amazon-braket-pytorch-jobs:latest
 RUN python3 -m pip install --upgrade pip
 
-# install cuda-quantum
+# install cudaq
 ARG SCRIPT_PATH
 ARG CUDAQ_PATH=/opt/conda/lib/python3.10/site-packages
 ENV MPI_PATH=/opt/amazon/openmpi
 
-COPY "${SCRIPT_PATH}/cudaq_wheel/wheelhouse/cuda_quantum_cu12-0.0.0-cp310-cp310-manylinux_2_28_x86_64.whl" .
-RUN python3 -m pip install cuda_quantum_cu12-0.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
+RUN python3 -m pip install cudaq
 RUN bash "${CUDAQ_PATH}/distributed_interfaces/activate_custom_mpi.sh"
 
 # install additional python dependencies

--- a/examples/nvidia_cuda_q/container/container_build_and_push.sh
+++ b/examples/nvidia_cuda_q/container/container_build_and_push.sh
@@ -50,11 +50,6 @@ docker login -u AWS -p $(aws ecr get-login-password --region us-west-2) 29228298
 # with the full name.
 script_dir=$(dirname "$0")
 
-# download cudaq wheel files
-wget -O container/cudaq_wheel.zip https://github.com/bettinaheim/cuda-quantum/releases/download/11272024/wheelhouse.zip
-unzip container/cudaq_wheel.zip -d container/cudaq_wheel
-
-# build docker image
 docker build --build-arg SCRIPT_PATH="$script_dir" \
 -t ${image} -f "${script_dir}/Dockerfile" . --platform linux/amd64 --progress=plain \
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that cudaq v0.9.1 is released, we can use the version directly from PyPI rather than installing the wheel manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
