### PR TITLE
fix: Pin mistune to 3.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ jaxlib==0.4.29 # Jaxlib 0.4.31 requires Python >=3.10
 jinja2==3.1.4
 markupsafe==3.0.2
 matplotlib==3.9.3
+mistune==3.0.2 # pin until https://github.com/lepture/mistune/issues/403 is resolved
 ml-dtypes==0.5.0
 mypy-extensions==1.0.0
 numpy==1.26.4 # Numpy 2.1.0 requires Python >=3.10, cirq-core 1.4.0 depends on numpy~=1.22


### PR DESCRIPTION
mistune introduced a bug in 3.10 that's causing nbconvert to fail; this change pins the version until the bug is fixed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
