### PR TITLE
fix: Pin PennyLane

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ openfermion==1.6.1
 openfermionpyscf==0.5
 optax==0.2.4
 pandas==2.2.3
-pennylane==0.38.0
-PennyLane-Lightning==0.38.0
+pennylane==0.35.1 # pin until we support higher glibc version
+PennyLane-Lightning==0.35.1 # pin until we support higher glibc version
 qiskit-aer==0.15.1
 qiskit-algorithms==0.3.1
 qiskit-braket-provider==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ botocore==1.35.76
 awscli==1.36.17
 boto3==1.35.76
 amazon-braket-default-simulator==1.26.2
-amazon-braket-pennylane-plugin==1.31.0
+amazon-braket-pennylane-plugin==1.28.0 # pin until we support higher glibc version
 amazon-braket-schemas==1.22.4
 amazon-braket-sdk==1.88.3
 amazon-braket-algorithm-library==1.5.1


### PR DESCRIPTION
Braket notebooks are still on an older version of glibc, so we need to keep PennyLane pinned

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
