### PR TITLE
fix: update to amazon-braket-sdk v1.89.1

### DIFF
--- a/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
+++ b/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
@@ -104,7 +104,7 @@
    "outputs": [],
    "source": [
     "# set up Rigetti quantum device\n",
-    "rigetti = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "rigetti = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "# set up IonQ quantum device\n",
     "ionq = AwsDevice(Devices.IonQ.Aria1)\n",

--- a/examples/braket_features/Allocating_Qubits_on_QPU_Devices.ipynb
+++ b/examples/braket_features/Allocating_Qubits_on_QPU_Devices.ipynb
@@ -81,7 +81,7 @@
     }
    ],
    "source": [
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "connectivity_graph = device.properties.paradigm.connectivity.connectivityGraph\n",
     "print(f\"the connectivity of {device.name} is: {connectivity_graph}\")"

--- a/examples/braket_features/Getting_Devices_and_Checking_Device_Properties.ipynb
+++ b/examples/braket_features/Getting_Devices_and_Checking_Device_Properties.ipynb
@@ -370,7 +370,7 @@
    "source": [
     "# specify a device directly by device ARN\n",
     "# Rigetti\n",
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "# IonQ\n",
     "device = AwsDevice(Devices.IonQ.Aria1)\n",
     "# IQM\n",
@@ -1862,7 +1862,7 @@
     "device = AwsDevice(Devices.IQM.Garnet)\n",
     "\n",
     "# the Rigetti device\n",
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "execution_windows = device.properties.service.executionWindows\n",
     "connectivity_graph = device.properties.paradigm.connectivity\n",

--- a/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb
+++ b/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb
@@ -1079,7 +1079,7 @@
     }
    ],
    "source": [
-    "AwsDevice(Devices.Rigetti.Ankaa2).properties.action[\n",
+    "AwsDevice(Devices.Rigetti._Ankaa2).properties.action[\n",
     "    \"braket.ir.openqasm.program\"\n",
     "].requiresAllQubitsMeasurement"
    ]
@@ -1157,7 +1157,7 @@
    ],
    "source": [
     "# choose the quantum device\n",
-    "rigetti = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "rigetti = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "ghz_program_with_physical_qubits_task = rigetti.run(\n",
     "    OpenQASMProgram(source=ghz_program_with_physical_qubits), shots=10\n",

--- a/examples/braket_features/Noise_models/Noise_models_on_Rigetti.ipynb
+++ b/examples/braket_features/Noise_models/Noise_models_on_Rigetti.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rigetti = AwsDevice(Devices.Rigetti.Ankaa2)"
+    "rigetti = AwsDevice(Devices.Rigetti._Ankaa2)"
    ]
   },
   {

--- a/examples/braket_features/Verbatim_Compilation.ipynb
+++ b/examples/braket_features/Verbatim_Compilation.ipynb
@@ -90,7 +90,7 @@
    ],
    "source": [
     "# set up the Rigetti Ankaa-2 device\n",
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "# list the native gate set\n",
     "print(\"The native gates for the\", device.name, \"device are:\")\n",
@@ -386,7 +386,7 @@
    ],
    "source": [
     "# set up the Rigetti Ankaa-2 device\n",
-    "rigetti = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "rigetti = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "# access and visualize the device topology\n",
     "# note that device topology can change day-to-day based on edge fidelity data\n",

--- a/examples/getting_started/2_Running_quantum_circuits_on_QPU_devices/2_Running_quantum_circuits_on_QPU_devices.ipynb
+++ b/examples/getting_started/2_Running_quantum_circuits_on_QPU_devices/2_Running_quantum_circuits_on_QPU_devices.ipynb
@@ -97,7 +97,7 @@
     "print(\"\\n\")\n",
     "\n",
     "# the Rigetti device\n",
-    "rigetti = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "rigetti = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "supported_gates = rigetti.properties.action[DeviceActionType.OPENQASM].supportedOperations\n",
     "# print the supported gate set\n",
     "print(\"Gate set supported by the Rigetti Ankaa-2 device:\\n\", supported_gates)\n",
@@ -869,7 +869,7 @@
    ],
    "source": [
     "# set up device\n",
-    "rigetti = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "rigetti = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "# run circuit\n",
     "task = rigetti.run(bell, shots=1000)\n",

--- a/examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb
+++ b/examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb
@@ -842,7 +842,7 @@
     "device = AwsDevice(Devices.Amazon.SV1)\n",
     "\n",
     "# set up the device to be the Rigetti quantum computer\n",
-    "# device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "# device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "\n",
     "# set up the device to be the IonQ quantum computer\n",
     "# device = AwsDevice(Devices.IonQ.Aria1)\n",

--- a/examples/hybrid_jobs/0_Creating_your_first_Hybrid_Job/0_Creating_your_first_Hybrid_Job.ipynb
+++ b/examples/hybrid_jobs/0_Creating_your_first_Hybrid_Job/0_Creating_your_first_Hybrid_Job.ipynb
@@ -436,7 +436,7 @@
    "source": [
     "from braket.devices import Devices\n",
     "\n",
-    "device_arn = Devices.Rigetti.Ankaa2\n",
+    "device_arn = Devices.Rigetti._Ankaa2\n",
     "\n",
     "\n",
     "@hybrid_job(device=device_arn)  # set priority QPU\n",

--- a/examples/hybrid_jobs/7_Running_notebooks_as_hybrid_jobs/Running_notebooks_as_hybrid_jobs.ipynb
+++ b/examples/hybrid_jobs/7_Running_notebooks_as_hybrid_jobs/Running_notebooks_as_hybrid_jobs.ipynb
@@ -248,7 +248,7 @@
     "\n",
     "devices = [\n",
     "    Devices.Amazon.SV1,\n",
-    "    Devices.Rigetti.Ankaa2,\n",
+    "    Devices.Rigetti._Ankaa2,\n",
     "    Devices.IonQ.Aria1,\n",
     "]\n",
     "\n",

--- a/examples/hybrid_jobs/8_Creating_Hybrid_Job_Scripts/Creating_your_first_Hybrid_Job.ipynb
+++ b/examples/hybrid_jobs/8_Creating_Hybrid_Job_Scripts/Creating_your_first_Hybrid_Job.ipynb
@@ -351,7 +351,7 @@
    ],
    "source": [
     "# Select the device on which you will be submitting your hybrid job.\n",
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "device.queue_depth().jobs"
    ]
   },
@@ -369,7 +369,7 @@
    "outputs": [],
    "source": [
     "# qpu_job = AwsQuantumJob.create(\n",
-    "#     device=Devices.Rigetti.Ankaa2,\n",
+    "#     device=Devices.Rigetti._Ankaa2,\n",
     "#     source_module=\"algorithm_script.py\",\n",
     "#     wait_until_complete=False,\n",
     "# )"

--- a/examples/hybrid_quantum_algorithms/QAOA/QAOA_braket.ipynb
+++ b/examples/hybrid_quantum_algorithms/QAOA/QAOA_braket.ipynb
@@ -309,7 +309,7 @@
     "## choose the on-demand simulator to run your circuit\n",
     "# device = AwsDevice(Devices.Amazon.SV1)\n",
     "## choose the Rigetti device to run your circuit\n",
-    "# device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "# device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "## choose the Ionq device to run your circuit\n",
     "# device = AwsDevice(Devices.IonQ.Aria1)\n",
     "## choose the IQM device to run your circuit\n",

--- a/examples/hybrid_quantum_algorithms/VQE_Transverse_Ising/VQE_Transverse_Ising_Model.ipynb
+++ b/examples/hybrid_quantum_algorithms/VQE_Transverse_Ising/VQE_Transverse_Ising_Model.ipynb
@@ -183,7 +183,7 @@
     "## choose the on-demand simulator to run your circuit\n",
     "# device = AwsDevice(Devices.Amazon.SV1)\n",
     "## choose the Rigetti device to run your circuit\n",
-    "# device = AwsDevice(Devices.Rigetti.Ankaa2)\n",
+    "# device = AwsDevice(Devices.Rigetti._Ankaa2)\n",
     "## choose the Ionq device to run your circuit\n",
     "# device = AwsDevice(Devices.IonQ.Aria1)\n",
     "## choose the IQM device to run your circuit\n",

--- a/examples/pennylane/0_Getting_started/0_Getting_started.ipynb
+++ b/examples/pennylane/0_Getting_started/0_Getting_started.ipynb
@@ -564,7 +564,7 @@
     "from braket.jobs.metrics import log_metric\n",
     "\n",
     "device_arn = Devices.Amazon.SV1\n",
-    "# device_arn = Devices.Rigetti.Ankaa2\n",
+    "# device_arn = Devices.Rigetti._Ankaa2\n",
     "\n",
     "\n",
     "@hybrid_job(device=device_arn)  # set priority QPU\n",

--- a/examples/pulse_control/1_Bringup_experiments.ipynb
+++ b/examples/pulse_control/1_Bringup_experiments.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "experiment_configuration = {\n",
     "    \"ankaa\": {\n",
-    "        \"device_arn\": Devices.Rigetti.Ankaa2,\n",
+    "        \"device_arn\": Devices.Rigetti._Ankaa2,\n",
     "        \"qubit\": 3,\n",
     "        \"drive_frame\": \"Transmon_3_charge_tx\",\n",
     "        \"readout_frame\": \"Transmon_3_readout_rx\",\n",

--- a/examples/pulse_control/2_Native_gate_calibrations.ipynb
+++ b/examples/pulse_control/2_Native_gate_calibrations.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)"
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)"
    ]
   },
   {

--- a/examples/pulse_control/3_Bell_pair_with_pulses_Rigetti.ipynb
+++ b/examples/pulse_control/3_Bell_pair_with_pulses_Rigetti.ipynb
@@ -67,7 +67,7 @@
     "a = 30\n",
     "b = 37\n",
     "\n",
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)"
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)"
    ]
   },
   {

--- a/examples/pulse_control/4_Build_single_qubit_gates.ipynb
+++ b/examples/pulse_control/4_Build_single_qubit_gates.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = AwsDevice(Devices.Rigetti.Ankaa2)"
+    "device = AwsDevice(Devices.Rigetti._Ankaa2)"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3==1.36.17
 amazon-braket-default-simulator==1.26.4
 amazon-braket-pennylane-plugin==1.28.0 # pin until we support higher glibc version
 amazon-braket-schemas==1.23.1
-amazon-braket-sdk==1.88.3
+amazon-braket-sdk==1.89.1
 amazon-braket-algorithm-library==1.5.1
 cvxpy==1.6.0
 ipykernel==6.29.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Includes renaming `Ankaa2` enum value to `_Ankaa2` for compatibility with `amazon-braket-sdk` v1.89.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
