### PR TITLE
Reduced-size CUDA-Q BYOC image based on pre-built Braket base jobs image

### DIFF
--- a/examples/nvidia_cuda_q/container/Dockerfile
+++ b/examples/nvidia_cuda_q/container/Dockerfile
@@ -1,17 +1,16 @@
-FROM 292282985366.dkr.ecr.us-west-2.amazonaws.com/amazon-braket-pytorch-jobs:latest
-RUN python3 -m pip install --upgrade pip
+FROM 292282985366.dkr.ecr.us-west-2.amazonaws.com/amazon-braket-base-jobs:latest
+
+ARG SCRIPT_PATH
 
 # install cudaq
-ARG SCRIPT_PATH
-ARG CUDAQ_PATH=/opt/conda/lib/python3.10/site-packages
-ENV MPI_PATH=/opt/amazon/openmpi
-
-RUN python3 -m pip install cudaq
-RUN bash "${CUDAQ_PATH}/distributed_interfaces/activate_custom_mpi.sh"
+ENV MPI_PATH=/usr/local
+RUN pip install cudaq mpi4py
+RUN bash /usr/local/lib/python3.10/site-packages/distributed_interfaces/activate_custom_mpi.sh
 
 # install additional python dependencies
-RUN python3 -m pip install --no-cache --upgrade -r requirements.txt
+COPY "${SCRIPT_PATH}/requirements.txt" .
+RUN pip install --no-cache --upgrade -r requirements.txt
 
-# Setup our entry point
+# setup the entry point
 COPY "${SCRIPT_PATH}/braket_container.py" /opt/ml/code/braket_container.py
 ENV SAGEMAKER_PROGRAM=braket_container.py


### PR DESCRIPTION
*Issue #, if available:* [#678](https://github.com/amazon-braket/amazon-braket-examples/issues/678)

*Description of changes:*
Replace the Dockerfile for the CUDA-Q BYOC image currently based on the pre-built Braket PyTorch image with a version based on the pre-built Braket base jobs image. This reduces the size of the image on ECR from 13 GB to 4 GB and the time span to pull the image and start the job from more than 6 minutes to about 90 seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
