### PR TITLE
fix: define pennylane functions inside decorator job

### DIFF
--- a/examples/pennylane/3_Hydrogen_Molecule_geometry_with_VQE/3_Hydrogen_Molecule_geometry_with_VQE.ipynb
+++ b/examples/pennylane/3_Hydrogen_Molecule_geometry_with_VQE/3_Hydrogen_Molecule_geometry_with_VQE.ipynb
@@ -526,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,6 +542,22 @@
     ")\n",
     "def run_large_vqe(iterations):\n",
     "    task_tracker = Tracker().start()  # track Braket quantum tasks costs\n",
+    "\n",
+    "    dev = qml.device(\"lightning.qubit\", wires=qubits)\n",
+    "    params = np.random.normal(0, np.pi, len(singles) + len(doubles))\n",
+    "\n",
+    "    @qml.qnode(dev)\n",
+    "    def energy_expval(params):\n",
+    "        circuit(params, wires)\n",
+    "        return qml.expval(h)\n",
+    "\n",
+    "    @qml.qnode(dev)\n",
+    "    def S2_expval(params):\n",
+    "        circuit(params, wires)\n",
+    "        return qml.expval(S2)\n",
+    "\n",
+    "    def spin(params):\n",
+    "        return -0.5 + np.sqrt(1 / 4 + S2_expval(params))\n",
     "\n",
     "    energies, spins = run_vqe(energy_expval, spin, opt, params, iterations)\n",
     "\n",
@@ -567,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -579,7 +595,7 @@
     }
    ],
    "source": [
-    "job = run_large_vqe(iterations=30)\n",
+    "job = run_large_vqe(iterations=15)\n",
     "print(job)"
    ]
   },


### PR DESCRIPTION
*Description of changes:*
Move `@qnode(dev)` decorated function inside the decorator job


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
