### PR TITLE
infra: update record utils to handle additional attributes

### DIFF
--- a/test/integ_tests/record_utils.py
+++ b/test/integ_tests/record_utils.py
@@ -42,9 +42,9 @@ class BraketClientWrapper:
         self.num_create_task_calls += 1
         return result
 
-    def get_quantum_task(self, quantumTaskArn):
+    def get_quantum_task(self, quantumTaskArn, **kwargs):
         if recording:
-            result = self.braket_client.get_quantum_task(quantumTaskArn=quantumTaskArn)
+            result = self.braket_client.get_quantum_task(quantumTaskArn=quantumTaskArn, additionalAttributeNames=["QueueInfo"])
             with open(f"get_task_results_{self.num_get_task_calls}.json", "w") as f:
                 json.dump(result, f, indent=2, default=str)
             if result["status"] in braket.aws.aws_quantum_task.AwsQuantumTask.TERMINAL_STATES:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- additional attributes are required to properly record the notebook when running the script to add notebook mocks specified in the testing readme. 
- Without this call failed for get_quantum_task for one of the notebook, that was excluded from the test. 

- tested with one notebook file which was causing errors to record results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
