### PR TITLE
infra: uncomment code blocks programmatically for testing, remove randomness notebook from excluded list

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -80,7 +80,7 @@ Re-running the notebook will use the generated files made during recording.
 
 In the example notebooks, some code cells are presented as commented out to prevent accidental execution of costly or long-running operations, particularly those that run on a QPU. However, commented code can become prone to errors over time due to lack of regular testing.
 
-To improve test coverage, we introduce a special flag: `# UNCOMMENT_TO_RUN`. As a developer, you can include this flag within a cell to mark the beginning of a block that should be uncommented during integration testing. The integration test framework will detect the # UNCOMMENT_TO_RUN marker and automatically uncomment all subsequent lines until it encounters a line that is not commented.
+To improve test coverage, we introduce a special flag: `## UNCOMMENT_TO_RUN`. As a developer, you can include this flag within a cell to mark the beginning of a block that should be uncommented during integration testing. The integration test framework will detect the `## UNCOMMENT_TO_RUN` marker and automatically uncomment all subsequent lines until it encounters a line that is not commented.
 
 To ensure this process works correctly:
 - Use a single `#` for code comments that should be uncommented during testing.

--- a/TESTING.md
+++ b/TESTING.md
@@ -75,3 +75,16 @@ Simply append the following line to the code cell specified in the Recording sec
 record_utils.playback()
 ```
 Re-running the notebook will use the generated files made during recording.
+
+## Testing commented code
+
+In the example notebooks, some code cells are presented as commented out to prevent accidental execution of costly or long-running operations, particularly those that run on a QPU. However, commented code can become prone to errors over time due to lack of regular testing.
+
+To improve test coverage, we introduce a special flag: `# UNCOMMENT_TO_RUN`. As a developer, you can include this flag within a cell to mark the beginning of a block that should be uncommented during integration testing. The integration test framework will detect the # UNCOMMENT_TO_RUN marker and automatically uncomment all subsequent lines until it encounters a line that is not commented.
+
+To ensure this process works correctly:
+- Use a single `#` for code comments that should be uncommented during testing.
+- Use double `##` for non-code, descriptive comments that should remain commented (and not be treated as executable code).
+
+Following this convention allows the integration test system to selectively and safely test example notebooks without risking unintended costly runs in normal usage.
+

--- a/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
+++ b/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-29T21:34:22.584748Z",
@@ -757,8 +757,8 @@
     "###\n",
     "\n",
     "# [Uncomment the following lines to use the Rigetti and IonQ devices. Be aware that a usage cost will incur when you submit the circuit.]\n",
-    "\n",
-    "# Rigetti: quantum circuit for generating weakly random bit string one\n",
+    "# UNCOMMENT_TO_RUN\n",
+    "## Rigetti: quantum circuit for generating weakly random bit string one\n",
     "# n1_q = (\n",
     "#     1  # alternatively use more than one qubit (attention: 32 max + lower bounds on number of shots)\n",
     "# )\n",
@@ -770,7 +770,7 @@
     "# rigetti_status = rigetti_task.state()\n",
     "# print(\"Status of Rigetti task:\", rigetti_status)\n",
     "\n",
-    "# IonQ: quantum circuit for generating weakly random bit string two\n",
+    "## IonQ: quantum circuit for generating weakly random bit string two\n",
     "# n2_q = (\n",
     "#     1  # alternatively use more than one qubit (attention: 11 max + lower bounds on number of shots)\n",
     "# )\n",

--- a/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
+++ b/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
@@ -757,7 +757,7 @@
     "###\n",
     "\n",
     "# [Uncomment the following lines to use the Rigetti and IonQ devices. Be aware that a usage cost will incur when you submit the circuit.]\n",
-    "# UNCOMMENT_TO_RUN\n",
+    "## UNCOMMENT_TO_RUN\n",
     "## Rigetti: quantum circuit for generating weakly random bit string one\n",
     "# n1_q = (\n",
     "#     1  # alternatively use more than one qubit (attention: 32 max + lower bounds on number of shots)\n",

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -8,7 +8,7 @@ from jupyter_client import kernelspec
 from nbconvert import HTMLExporter
 from testbook import testbook
 
-UNCOMMENT_NOTEBOOK_TAG = "# UNCOMMENT_TO_RUN"
+UNCOMMENT_NOTEBOOK_TAG = "## UNCOMMENT_TO_RUN"
 
 # These notebooks have syntax or dependency issues that prevent them from being tested.
 EXCLUDED_NOTEBOOKS = [

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -8,6 +8,8 @@ from jupyter_client import kernelspec
 from nbconvert import HTMLExporter
 from testbook import testbook
 
+UNCOMMENT_NOTEBOOK_TAG = "# UNCOMMENT_TO_RUN"
+
 # These notebooks have syntax or dependency issues that prevent them from being tested.
 EXCLUDED_NOTEBOOKS = [
     # These notebooks have cells that have syntax errors
@@ -183,7 +185,7 @@ def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
     for i, cell in enumerate(tb.cells):
         if cell.get("cell_type") == "code" and "source" in cell:
             source = cell["source"]
-            if "# UNCOMMENT_TO_RUN" in source:
+            if UNCOMMENT_NOTEBOOK_TAG in source:
                 # Uncomment the test section
                 modified_source = uncomment_test_section(source)
                 tb.cells[i]["source"] = modified_source
@@ -195,7 +197,7 @@ def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
 
 
 def uncomment_test_section(source):
-    """Uncomment sections marked with # UNCOMMENT_TO_RUN."""
+    """Uncomment sections marked with tag"""
     descriptive_comment = re.compile(r"^\s*##\s")
     regular_comment = re.compile(r"^\s*#\s?")
 
@@ -206,7 +208,7 @@ def uncomment_test_section(source):
     for line in lines:
         stripped_line = line.strip()
 
-        if stripped_line == "# UNCOMMENT_FOR_TEST":
+        if stripped_line == UNCOMMENT_NOTEBOOK_TAG:
             uncomment_mode = True
             result.append(line)
             continue

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -1,7 +1,7 @@
 import logging
 import os
-from importlib.machinery import SourceFileLoader
 import re
+from importlib.machinery import SourceFileLoader
 
 import pytest
 from jupyter_client import kernelspec
@@ -164,7 +164,7 @@ def check_cells_for_error_output(cells):
                 if output["output_type"] == "error":
                     pytest.fail("Found error output in cell: " + str(output))
 
-                     
+
 def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
     # We do this check to make sure that the notebook can be executed (with mocks).
     tb.inject(
@@ -178,7 +178,7 @@ def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
         run=False,
         before=0,
     )
-    
+
     # Uncomment all test sections in the notebook
     for i, cell in enumerate(tb.cells):
         if cell.get("cell_type") == "code" and "source" in cell:
@@ -187,39 +187,37 @@ def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
                 # Uncomment the test section
                 modified_source = uncomment_test_section(source)
                 tb.cells[i]["source"] = modified_source
-    
+
     # Execute the notebook with the uncommented test sections
     tb.execute()
     test_mocks = SourceFileLoader("notebook_mocks", path_to_mocks).load_module()
     test_mocks.post_run(tb)
 
-    
 
 def uncomment_test_section(source):
     """Uncomment sections marked with # UNCOMMENT_TO_RUN."""
-    descriptive_comment = re.compile(r'^\s*##\s')
-    regular_comment = re.compile(r'^\s*#\s?')
-    
-    
+    descriptive_comment = re.compile(r"^\s*##\s")
+    regular_comment = re.compile(r"^\s*#\s?")
+
     lines = source.splitlines()
     result = []
     uncomment_mode = False
-    
+
     for line in lines:
         stripped_line = line.strip()
-        
+
         if stripped_line == "# UNCOMMENT_FOR_TEST":
             uncomment_mode = True
             result.append(line)
             continue
-            
+
         if uncomment_mode:
             if descriptive_comment.match(stripped_line):
                 # Handle descriptive comments (##)
                 result.append(f"# {stripped_line[3:].lstrip()}")
             elif regular_comment.match(stripped_line):
                 # Handle regular comments (#)
-                result.append(regular_comment.sub('', line))
+                result.append(regular_comment.sub("", line))
             elif stripped_line:
                 # Non-empty, non-comment line
                 uncomment_mode = False
@@ -229,5 +227,5 @@ def uncomment_test_section(source):
                 result.append(line)
         else:
             result.append(line)
-            
-    return '\n'.join(result)
+
+    return "\n".join(result)


### PR DESCRIPTION
…domness notebook from excluded list

*Issue #, if available:*

*Description of changes:*
- uncomments the notebook commented cell blocks based on the identifier tag so that can run the test end to end for the notebook. 
- currently removed one notebook from the excluded list. 
- ran test with and without least mocking options. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
